### PR TITLE
Fix showKeyDialog closing markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+package-lock.json

--- a/src/App.js
+++ b/src/App.js
@@ -237,7 +237,7 @@ export default function App() {
             </div>
           </div>
         </div>
-      )
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- prevent build failure by closing the JSX block for `showKeyDialog`
- add `.gitignore` so build and node modules are not tracked

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400676eaa483208bebe3856027c532